### PR TITLE
Bring up udhcpd after WLAN gets up, set `wireless-mode Master`

### DIFF
--- a/roles/access-point/templates/interfaces.j2
+++ b/roles/access-point/templates/interfaces.j2
@@ -18,6 +18,7 @@ iface {{ lan_adapter }} inet manual
 
 auto {{ wifi_adapter }}
 iface {{ wifi_adapter }} inet static
+  wireless-mode Master
   address {{ own_ip }}
   netmask {{ subnet }}
   network {{ network }}

--- a/roles/access-point/templates/interfaces.j2
+++ b/roles/access-point/templates/interfaces.j2
@@ -23,4 +23,4 @@ iface {{ wifi_adapter }} inet static
   netmask {{ subnet }}
   network {{ network }}
   broadcast {{ broadcast }}
-
+  post-up /usr/sbin/udhcpd -S /etc/udhcpd.conf

--- a/roles/access-point/templates/udhcpd-init.j2
+++ b/roles/access-point/templates/udhcpd-init.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 #
 # Uncomment the following line to disable
-#DHCPD_ENABLED="no"
+DHCPD_ENABLED="no"
 
 # Options to pass to busybox' udhcpd.
 #


### PR DESCRIPTION
These were necessary for me to get this working on `buster`-based Raspberry OS. Feel free to cherry-pick, if unsure about either.